### PR TITLE
feat: replace functions that can panic with errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tlsn-js",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tlsn-js",
-      "version": "0.0.1",
+      "version": "0.0.2",
       "license": "ISC",
       "dependencies": {
         "comlink": "^4.4.1"

--- a/wasm/prover/src/request_opt.rs
+++ b/wasm/prover/src/request_opt.rs
@@ -1,12 +1,12 @@
-use std::{collections::HashMap};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Requestion Options of Fetch API
 // https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch
 #[derive(Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RequestOptions {
-    pub method: String,  // *GET, POST, PUT, DELETE, etc.
+    pub method: String, // *GET, POST, PUT, DELETE, etc.
     // pub mode: String, // no-cors, *cors, same-origin
     // pub cache: String, // *default, no-cache, reload, force-cache, only-if-cached
     // pub credentials: String, // include, *same-origin, omit
@@ -16,7 +16,7 @@ pub struct RequestOptions {
     pub body: String, // body data type must match "Content-Type" header
     pub max_transcript_size: usize,
     pub notary_url: String,
-	pub websocket_proxy_url: String,
+    pub websocket_proxy_url: String,
 }
 
 #[derive(Serialize, Deserialize)]


### PR DESCRIPTION
## What's wrong?
Per the discussion in https://github.com/tlsnotary/tlsn-extension/issues/27#issuecomment-1870262558, we used functions that can panic in our rust code, like `unwrap` and `expect`. If a panic happens, we must either restart a new wasm instance or catch the panic. However, [catching panics](https://doc.rust-lang.org/std/panic/fn.catch_unwind.html) is not recommended. Panic should only happen if there are serious errors that execution must abort. 

## How it is fixed?
Replace all functions that can panic with errors. This way we can catch them in Javascript and reuse the wasm instance.