### PR TITLE
Add vscode settings for rust-analyzer

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "rust-analyzer.linkedProjects": [
+        "wasm/prover/Cargo.toml"
+    ],
+    "rust-analyzer.cargo.target": "wasm32-unknown-unknown"
+}


### PR DESCRIPTION
## What's wrong?
In my laptop, `rust-analyzer` couldn't run correctly without a settings file specifying the `Cargo.toml`

## How it is fixed?
Add project path with target specified. If I understand it wrong or it's not the correct way to configure, please let me know and I will close this PR