### PR TITLE
Update ws_stream_wasm link

### DIFF
--- a/wasm/prover/Cargo.toml
+++ b/wasm/prover/Cargo.toml
@@ -68,7 +68,7 @@ web-sys = { version = "0.3.4", features = [
 
 
 # Use the patched ws_stream_wasm to fix the issue https://github.com/najamelan/ws_stream_wasm/issues/12#issuecomment-1711902958
-ws_stream_wasm = { version = "0.7.4", git = "https://github.com/mhchia/ws_stream_wasm", branch = "dev" }
+ws_stream_wasm = { version = "0.7.4", git = "https://github.com/tlsnotary/ws_stream_wasm", branch = "dev" }
 
 # The `console_error_panic_hook` crate provides better debugging of panics by
 # logging them with `console.error`. This is great for development, but requires


### PR DESCRIPTION
## What's done?
Per discussion in https://github.com/tlsnotary/tlsn-js/issues/1, `ws_stream_wasm` has been transferred under tlsnotary and thus the dependency should be updated