### PR TITLE
Support passing additional HTTP headers into interactive_prove().

### DIFF
--- a/interactive-demo/prover-ts/app.tsx
+++ b/interactive-demo/prover-ts/app.tsx
@@ -15,11 +15,15 @@ function App(): ReactElement {
 
   const onClick = useCallback(async () => {
     setProcessing(true);
-    const result = await interactive_prove(
-      'wss://notary.pse.dev/proxy?token=swapi.dev', //'ws://localhost:55688',
-      'ws://localhost:9816',
-      "https://swapi.dev/api/people/1",
-      "interactive-verifier-demo");
+    const result = await interactive_prove('https://swapi.dev/api/people/1', {
+      headers: {
+        RTT: '125',
+        'Sec-GPC': '1',
+      },
+      id: "interactive-verifier-demo",
+      verifierProxyUrl: 'ws://localhost:9816',
+      websocketProxyUrl: 'wss://notary.pse.dev/proxy?token=swapi.dev', //'ws://localhost:55688',
+    });
     setResult(result);
     setProcessing(false);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,19 +58,30 @@ export const prove = async (
 
 
 export const interactive_prove = async (
-  websocket_proxy_url: string,
-  verifier_proxy_url: string,
-  uri: string,
-  id: string
+  url: string,
+  options: {
+    headers?: { [key: string]: string };
+    id: string;
+    verifierProxyUrl: string;
+    websocketProxyUrl: string;
+  },
 ): Promise<string> => {
+
+  const {
+    headers,
+    id,
+    verifierProxyUrl,
+    websocketProxyUrl,
+  } = options;
+
   const tlsn = await getTLSN();
 
-
-  const proof = await tlsn.interactive_prove(
-    websocket_proxy_url,
-    verifier_proxy_url,
-    uri,
-    id);
+  const proof = await tlsn.interactive_prove(url, {
+    headers,
+    websocketProxyUrl,
+    verifierProxyUrl,
+    id,
+  });
 
   return proof
 };

--- a/src/tlsn.ts
+++ b/src/tlsn.ts
@@ -75,17 +75,23 @@ export default class TLSN {
   }
 
   async interactive_prove(
-    websocket_proxy_url: string,
-    verifier_proxy_url: string,
-    uri: string,
-    id: string,
+    url: string,
+    options?: {
+      headers?: { [key: string]: string };
+      id?: string;
+      verifierProxyUrl?: string;
+      websocketProxyUrl?: string;
+    },
   ) {
     await this.waitForStart();
     const resProver = await interactive_prover(
-      websocket_proxy_url,
-      verifier_proxy_url,
-      uri,
-      id
+      url,
+      {
+        ...options,
+        id: options?.id,
+        verifierProxyUrl: options?.verifierProxyUrl,
+        websocketProxyUrl: options?.websocketProxyUrl,
+      }
     );
     const resJSON = JSON.parse(resProver);
     // console.log('!@# resProver,resJSON=', { resProver, resJSON });

--- a/wasm/prover/src/request_opt.rs
+++ b/wasm/prover/src/request_opt.rs
@@ -27,3 +27,12 @@ pub struct VerifyResult {
     pub sent: String,
     pub recv: String,
 }
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct InteractiveRequestOptions {
+    pub headers: HashMap<String, String>,
+    pub id: String,
+    pub verifier_proxy_url: String,
+    pub websocket_proxy_url: String,
+}


### PR DESCRIPTION
With these changes, after the user starts the interactive prover demo in their browser and opens Developer tools, they should see some lines about additional headers being added to the request,e.g.:

```
     ...Object({"headers":{"RTT":"125","Sec-GPC":"1"},"websocketProxyUrl":"wss://notary.pse.dev/proxy?token=swapi.dev","verifierProxyUrl":"ws://localhost:9816","id":"interactive-verifier-demo"}))}: tlsn_extension_rs::interactive_prover: adding header: Sec-GPC - 1
     ...Object({"headers":{"RTT":"125","Sec-GPC":"1"},"websocketProxyUrl":"wss://notary.pse.dev/proxy?token=swapi.dev","verifierProxyUrl":"ws://localhost:9816","id":"interactive-verifier-demo"}))}: tlsn_extension_rs::interactive_prover: adding header: RTT - 125
```
