### PR TITLE
added note on non-xcode llvm fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -69,6 +69,10 @@ npm install tlsn-js
 
 > [!IMPORTANT]
 > **Note on Rust-to-WASM Compilation**: This project requires compiling Rust into WASM, which needs [`clang`](https://clang.llvm.org/) version 16.0.0 or newer. MacOS users, be aware that Xcode's default `clang` might be older. If you encounter the error `No available targets are compatible with triple "wasm32-unknown-unknown"`, it's likely due to an outdated `clang`. Updating `clang` to a newer version should resolve this issue.
+>
+> For MacOS aarch64 users, if Apple's clang isnt woking, try installing llvm via homebrew. Then set the following ENVs to get the build to work:<br>
+> ```export AR=/opt/homebrew/opt/llvm/bin/llvm-ar``` <br>
+> ```export CC=/opt/homebrew/opt/llvm/bin/clang```
 
 ```
 # make sure you have rust installed


### PR DESCRIPTION
on aarch64 Xcode 16.0
with Apple clang version 16.0.0 (clang-1600.0.23.1) I was still getting the no supported targets error, but installing llvm with homebrew worked, so I updated the readme to show how I did it.