### PR TITLE
fix: change webpack dev server port to avoid websocket conflict

### DIFF
--- a/demo/interactive-demo/README.md
+++ b/demo/interactive-demo/README.md
@@ -35,4 +35,4 @@ wstcp --bind-addr 127.0.0.1:55688 swapi.dev:443
         npm link
         npm run dev
         ```
-    3. Open <http://localhost:8080/> and click **Start Prover**
+    3. Open <http://localhost:3000/> and click **Start Prover**

--- a/demo/interactive-demo/README.md
+++ b/demo/interactive-demo/README.md
@@ -35,4 +35,4 @@ wstcp --bind-addr 127.0.0.1:55688 swapi.dev:443
         npm link
         npm run dev
         ```
-    3. Open <http://localhost:3000/> and click **Start Prover**
+    3. Open <http://localhost:3456/> and click **Start Prover**

--- a/demo/interactive-demo/prover-ts/webpack.js
+++ b/demo/interactive-demo/prover-ts/webpack.js
@@ -100,6 +100,9 @@ var options = {
   //  - https://github.com/GoogleChromeLabs/wasm-bindgen-rayon#setting-up
   //  - https://web.dev/i18n/en/coop-coep/
   devServer: {
+    port: 3000,
+    host: 'localhost',
+    hot: true,
     headers: {
       'Cross-Origin-Embedder-Policy': 'require-corp',
       'Cross-Origin-Opener-Policy': 'same-origin',

--- a/demo/interactive-demo/prover-ts/webpack.js
+++ b/demo/interactive-demo/prover-ts/webpack.js
@@ -105,7 +105,7 @@ var options = {
   //  - https://github.com/GoogleChromeLabs/wasm-bindgen-rayon#setting-up
   //  - https://web.dev/i18n/en/coop-coep/
   devServer: {
-    port: 3000,
+    port: 3456,
     host: 'localhost',
     hot: true,
     headers: {


### PR DESCRIPTION
Problem:
When running the demo prover-ts on macOS, encountered error:
"Invalid WebSocket frame: RSV1 must be clear"

Investigation:
- Several other macOS developers have reported this issue
- Found relevant discussions and similar cases
- You can find detailed discussions at: [websockets issues](https://github.com/websockets/ws/issues/2169)

Solution:
Based on the solutions shared in the [discussions](https://github.com/websockets/ws/issues/2169):
- Changed webpack-dev-server port from 8080 to 3000
- Successfully resolved the WebSocket connection issue