### PR TITLE
Recv and sent methods now supports utf-8 bodies

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -25,6 +25,7 @@ import {
   expect,
   headerToMap,
   hexToArray,
+  replaceZeroBytesWithSymbol,
 } from './utils';
 import { ParsedTranscriptData, PresentationJSON } from './types';
 
@@ -305,12 +306,12 @@ export class Presentation {
   constructor(
     params:
       | {
-          attestationHex: string;
-          secretsHex: string;
-          notaryUrl?: string;
-          websocketProxyUrl?: string;
-          reveal?: Reveal;
-        }
+        attestationHex: string;
+        secretsHex: string;
+        notaryUrl?: string;
+        websocketProxyUrl?: string;
+        reveal?: Reveal;
+      }
       | string,
   ) {
     if (typeof params === 'string') {
@@ -496,19 +497,11 @@ export class Transcript {
   }
 
   recv(redactedSymbol = '*') {
-    return this.#recv.reduce((recv: string, num) => {
-      recv =
-        recv + (num === 0 ? redactedSymbol : Buffer.from([num]).toString());
-      return recv;
-    }, '');
+    return Buffer.from(replaceZeroBytesWithSymbol(this.#recv, redactedSymbol)).toString();
   }
 
   sent(redactedSymbol = '*') {
-    return this.#sent.reduce((sent: string, num) => {
-      sent =
-        sent + (num === 0 ? redactedSymbol : Buffer.from([num]).toString());
-      return sent;
-    }, '');
+    return Buffer.from(replaceZeroBytesWithSymbol(this.#sent, redactedSymbol)).toString();
   }
 
   text = (redactedSymbol = '*') => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,56 +3,56 @@ import { Buffer } from 'buffer';
 
 type Stack =
   | {
-      type: 'object';
-      symbol: string;
-      range: [number, number];
-      id: number;
-    }
+    type: 'object';
+    symbol: string;
+    range: [number, number];
+    id: number;
+  }
   | {
-      type: 'array';
-      symbol: string;
-      range: [number, number];
-      data: string;
-      id: number;
-    }
+    type: 'array';
+    symbol: string;
+    range: [number, number];
+    data: string;
+    id: number;
+  }
   | {
-      type: 'object_key';
-      symbol: string;
-      range: [number, number];
-      data: string;
-      path: string;
-      id: number;
-      objectId: number;
-    }
+    type: 'object_key';
+    symbol: string;
+    range: [number, number];
+    data: string;
+    path: string;
+    id: number;
+    objectId: number;
+  }
   | {
-      type: 'object_value';
-      symbol: string;
-      range: [number, number];
-      data: string;
-      id: number;
-      keyId: number;
-      objectId: number;
-    }
+    type: 'object_value';
+    symbol: string;
+    range: [number, number];
+    data: string;
+    id: number;
+    keyId: number;
+    objectId: number;
+  }
   | {
-      type: 'object_value_string';
-      symbol: string;
-      range: [number, number];
-      data: string;
-      path: string;
-      id: number;
-      objectId: number;
-      valueId: number;
-    }
+    type: 'object_value_string';
+    symbol: string;
+    range: [number, number];
+    data: string;
+    path: string;
+    id: number;
+    objectId: number;
+    valueId: number;
+  }
   | {
-      type: 'object_value_number';
-      symbol: string;
-      range: [number, number];
-      data: string;
-      path: string;
-      id: number;
-      objectId: number;
-      valueId: number;
-    };
+    type: 'object_value_number';
+    symbol: string;
+    range: [number, number];
+    data: string;
+    path: string;
+    id: number;
+    objectId: number;
+    valueId: number;
+  };
 
 type Commitment = {
   name?: string;
@@ -290,6 +290,22 @@ export function processJSON(str: string): Commitment[] {
     start,
     end,
   }));
+}
+
+export function replaceZeroBytesWithSymbol(buf: number[], symbol: string) {
+  const redactedSymbolBytes = [...Buffer.from(symbol, 'utf-8')];
+
+  let transformedBuffer: number[] = []
+
+  buf.forEach((num) => {
+    if (num === 0) {
+      transformedBuffer = transformedBuffer.concat(redactedSymbolBytes);
+    } else {
+      transformedBuffer.push(num);
+    }
+  })
+
+  return transformedBuffer
 }
 
 export function processTranscript(transcript: string): ParsedTranscriptData {


### PR DESCRIPTION
In the elder version of the methods, utf-8 characters bytes replaced just with new Blob([]) which is not right encoding format for them. This code fixed the presentation problem of the recv and sent text messages