### PR TITLE
ci: notary server has tls disabled by default since alpha.11

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,6 @@ jobs:
     services:
       notary-server:
         image: ghcr.io/tlsnotary/tlsn/notary-server:v0.1.0-alpha.11
-        env:
-          NOTARY_SERVER__TLS__ENABLED: false
         ports:
           - 7047:7047
     steps:


### PR DESCRIPTION
re #107 