### PR TITLE
build: Pin transitive dependencies for tlsn alpha.12

### DIFF
--- a/demo/interactive-demo/prover-rs/Cargo.toml
+++ b/demo/interactive-demo/prover-rs/Cargo.toml
@@ -8,25 +8,31 @@ async-tungstenite = { version = "0.25", features = ["tokio-runtime"] }
 futures = "0.3"
 http = "1.1"
 http-body-util = "0.1"
-hyper = {version = "1.1", features = ["client", "http1"]}
-hyper-util = {version = "0.1", features = ["full"]}
+hyper = { version = "1.1", features = ["client", "http1"] }
+hyper-util = { version = "0.1", features = ["full"] }
 regex = "1.10.3"
-tokio = {version = "1", features = [
+tokio = { version = "1", features = [
   "rt",
   "rt-multi-thread",
   "macros",
   "net",
   "io-std",
   "fs",
-]}
+] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tracing = "0.1.40"
-tracing-subscriber = { version ="0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 uuid = { version = "1.4.1", features = ["v4", "fast-rng"] }
 ws_stream_tungstenite = { version = "0.13", features = ["tokio_io"] }
 
 tlsn-core = { git = "https://github.com/tlsnotary/tlsn.git", tag = "v0.1.0-alpha.12", package = "tlsn-core" }
 tlsn-prover = { git = "https://github.com/tlsnotary/tlsn.git", tag = "v0.1.0-alpha.12", package = "tlsn-prover" }
 tlsn-common = { git = "https://github.com/tlsnotary/tlsn.git", tag = "v0.1.0-alpha.12", package = "tlsn-common" }
-spansy = {git = "https://github.com/tlsnotary/tlsn-utils", package = "spansy", branch = "dev"}
+spansy = { git = "https://github.com/tlsnotary/tlsn-utils", package = "spansy", branch = "dev" }
 rangeset = "0.2.0"
+
+# --- Transitive dependency pins (for TLSNotary alpha.12)---
+aes = "=0.9.0-rc.0"
+cipher = "=0.5.0-rc.0"
+crypto-common = "=0.2.0-rc.3"
+inout = "=0.2.0-rc.5"

--- a/demo/interactive-demo/verifier-rs/Cargo.toml
+++ b/demo/interactive-demo/verifier-rs/Cargo.toml
@@ -17,22 +17,28 @@ hyper = { version = "1.1", features = ["client", "http1", "server"] }
 hyper-util = { version = "0.1", features = ["full"] }
 serde = { version = "1.0.147", features = ["derive"] }
 sha1 = "0.10"
-tokio = {version = "1", features = [
+tokio = { version = "1", features = [
   "rt",
   "rt-multi-thread",
   "macros",
   "net",
   "io-std",
   "fs",
-]}
+] }
 tokio-util = { version = "0.7", features = ["compat"] }
 tower = { version = "0.4.12", features = ["make"] }
 tower-service = { version = "0.3" }
 tracing = "0.1.40"
-tracing-subscriber = { version ="0.3.18", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 ws_stream_tungstenite = { version = "0.13", features = ["tokio_io"] }
 
 tlsn-core = { git = "https://github.com/tlsnotary/tlsn.git", tag = "v0.1.0-alpha.12", package = "tlsn-core" }
 tlsn-verifier = { git = "https://github.com/tlsnotary/tlsn.git", tag = "v0.1.0-alpha.12", package = "tlsn-verifier" }
 tlsn-common = { git = "https://github.com/tlsnotary/tlsn.git", tag = "v0.1.0-alpha.12", package = "tlsn-common" }
 tower-util = "0.3.1"
+
+# --- Transitive dependency pins (for TLSNotary alpha.12)---
+aes = "=0.9.0-rc.0"
+cipher = "=0.5.0-rc.0"
+crypto-common = "=0.2.0-rc.3"
+inout = "=0.2.0-rc.5"


### PR DESCRIPTION
Workaround for #114 